### PR TITLE
Don't expect a status in 0x1901 packets from the FCU

### DIFF
--- a/config/packetDefinitions.js
+++ b/config/packetDefinitions.js
@@ -93,7 +93,6 @@ module.exports = {
 				"DAQ":false,
 				"Parameters":[
 								{'Name':'State', 'type':'uint32', 'units':'', 'size': 4},
-								{'Name':'Status', 'type':'uint8', 'units':'', 'size': 1}
 							]
 			},
 			{

--- a/server/DataGenerators/TestPayloads.js
+++ b/server/DataGenerators/TestPayloads.js
@@ -284,11 +284,9 @@ BMSStreaming.push.apply(BMSStreaming, bin.uint32ToBytes(20,true)); //Temp Scan C
  */
 var autoSequenceTestResult1 = [];
 autoSequenceTestResult1.push.apply(autoSequenceTestResult1, bin.uint32ToBytes(1, true)); // Idle
-autoSequenceTestResult1.push.apply(autoSequenceTestResult1, bin.uint8ToBytes(1, true)); // Pass
 
 var autoSequenceTestResult3 = [];
 autoSequenceTestResult3.push.apply(autoSequenceTestResult3, bin.uint32ToBytes(3, true)); // Brake sensing
-autoSequenceTestResult3.push.apply(autoSequenceTestResult3, bin.uint8ToBytes(0, true)); // Fail
 
 
 /*


### PR DESCRIPTION
@rutayanp can you confirm that Status is now gone from the 0x1901 packets?

Note that before this change, the /autoSequence page would show Pending, Pass, Fail, and Timeout statuses.

Now it'll only show Pending, Pass, and Timeout since the FCU will no longer have a way to indicate Pass vs. Fail.