### PR TITLE
add enum status display component and use it

### DIFF
--- a/src/components/EnumStatusDisplay.js
+++ b/src/components/EnumStatusDisplay.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+
+class EnumStatusDisplay extends GenericParameterDisplay {
+  /*
+  * This component inherits all code from GenericParameterDisplay. Look there for implemetation details
+  */
+  render () {
+    let value = this.props.enumMap[this.state.value];
+    let color = 'black';
+    if (this.state.stale) {
+      value = 'STALE';
+      color = 'red';
+    }
+    if (this.props.colorMap && !this.state.stale) {
+      color = this.props.colorMap[this.state.value] || 'black';
+    }
+    return (
+      <div className='form-group row' style={this.props.style}>
+        <label className='col-sm-6' style={{fontWeight: 600}}>
+        {this.props.name}
+        </label>
+        <div className='col-sm-6'>
+          <div className='Generic-Value'>
+            <span style={{color: color}}>{value}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default EnumStatusDisplay;


### PR DESCRIPTION
Adding component in which you can define enum mapping and color mapping (instead of using the HEX values as before). Also using this for Pod Status and Brake State. The Pod Status is not available in Packets yet.